### PR TITLE
Enable Dependabot for Python and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+  # Maintain dependencies for Docker image(s)
+  -
+    package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+  # Maintain dependencies for Python packages
+  -
+    package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
**Scope of the pull request**

The PR enables Dependabot for Python and Docker ecosystems

**Solved issues**

- Close #5 

**Added issues**

None

**Tests**

- [ ] I manually tested it
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
