### PR TITLE
Generate validation report as JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ private: install cleanup
 		--sector private
 
 validate-public:
-	spid-compliant-certificates validator
+	spid-compliant-certificates validator --out-file report.json
 
 validate-private:
-	spid-compliant-certificates validator --sector private
+	spid-compliant-certificates validator --sector private --out-file report.json
 
 docker-build:
 	docker build --tag $(REPO):$(GIT_COMMIT) .

--- a/bin/spid-compliant-certificates
+++ b/bin/spid-compliant-certificates
@@ -68,7 +68,10 @@ def logo():
 
 ''')  # noqa
 
-# main
+
+def _indent(txt: str, count=1) -> str:
+    i = '  '
+    return f'{i * count}{txt}'
 
 
 if __name__ == '__main__':
@@ -206,6 +209,21 @@ if __name__ == '__main__':
         type=pathlib.Path
     )
 
+    parser_v.add_argument(
+        '--out-form',
+        action='store',
+        choices=['txt', 'json', 'xml'],
+        default='json',
+        help='select the output file format'
+    )
+
+    parser_v.add_argument(
+        '--out-file',
+        action='store',
+        help='file where the validation report will be saved',
+        type=pathlib.Path
+    )
+
     logo()
     args = parser.parse_args()
 
@@ -238,19 +256,33 @@ if __name__ == '__main__':
             LOG.error(f'Unable to find certificate file {args.crt_file}')
             sys.exit(1)
         try:
-            LOG.info(f'Validating certificate {args.crt_file} '
+            LOG.info(f'Validating certificate {args.crt_file.absolute()} '
                      + f'against {args.sector} sector specifications')
             r = validate(args.crt_file, args.sector)
-            rs = ReportSerializer()
 
+            msg = f'Certificate {args.crt_file.absolute()} '
             if r.result == 'success':
-                LOG.info('It is ok')
-                LOG.info(rs.serialize(r, 'json'))
-            elif r.result == 'failure':
-                LOG.error('It is not good')
-                LOG.error(rs.serialize(r, 'json'))
+                msg += f'matches the {args.sector} sector specifications'
+                LOG.info(msg)
             else:
-                LOG.warn('Something gone wrong')
+                msg += f'violates the {args.sector} sector specifications'
+                LOG.error(msg)
+
+            for t in r.tests:
+                log = LOG.info if t.result == 'success' else LOG.error
+                log(_indent(t.description))
+                for c in t.checks:
+                    log = LOG.info if c.result == 'success' else LOG.error
+                    log(_indent(c.description, 2))
+
+            if args.out_file is not None:
+                msg = f'Saving report as {args.out_form.upper()} '
+                msg += f'in {args.out_file.absolute()}'
+                LOG.info(msg)
+                rs = ReportSerializer()
+                with open(args.out_file, 'wb') as fp:
+                    fp.write(rs.serialize(r, args.out_form).encode())
+                    fp.close()
 
         except Exception as e:
             LOG.error(e)

--- a/bin/spid-compliant-certificates
+++ b/bin/spid-compliant-certificates
@@ -273,7 +273,7 @@ if __name__ == '__main__':
                 log(_indent(t.description))
                 for c in t.checks:
                     log = LOG.info if c.is_success() else LOG.error
-                    log(_indent(c.description, 2))
+                    log(_indent(f'{c.description} (now: {c.value})', 2))
 
             if args.out_file is not None:
                 msg = f'Saving report as {args.out_form.upper()} '

--- a/bin/spid-compliant-certificates
+++ b/bin/spid-compliant-certificates
@@ -30,6 +30,7 @@ from spid_compliant_certificates import version
 from spid_compliant_certificates.commons import logger
 from spid_compliant_certificates.generator import generate
 from spid_compliant_certificates.validator import validate
+from spid_compliant_certificates.validator.report import ReportSerializer
 
 LOG = logger.LOG
 
@@ -239,7 +240,18 @@ if __name__ == '__main__':
         try:
             LOG.info(f'Validating certificate {args.crt_file} '
                      + f'against {args.sector} sector specifications')
-            validate(args.crt_file, args.sector)
+            r = validate(args.crt_file, args.sector)
+            rs = ReportSerializer()
+
+            if r.result == 'success':
+                LOG.info('It is ok')
+                LOG.info(rs.serialize(r, 'json'))
+            elif r.result == 'failure':
+                LOG.error('It is not good')
+                LOG.error(rs.serialize(r, 'json'))
+            else:
+                LOG.warn('Something gone wrong')
+
         except Exception as e:
             LOG.error(e)
             sys.exit(1)

--- a/bin/spid-compliant-certificates
+++ b/bin/spid-compliant-certificates
@@ -261,7 +261,7 @@ if __name__ == '__main__':
             r = validate(args.crt_file, args.sector)
 
             msg = f'Certificate {args.crt_file.absolute()} '
-            if r.result == 'success':
+            if r.is_success():
                 msg += f'matches the {args.sector} sector specifications'
                 LOG.info(msg)
             else:
@@ -269,10 +269,10 @@ if __name__ == '__main__':
                 LOG.error(msg)
 
             for t in r.tests:
-                log = LOG.info if t.result == 'success' else LOG.error
+                log = LOG.info if t.is_success() else LOG.error
                 log(_indent(t.description))
                 for c in t.checks:
-                    log = LOG.info if c.result == 'success' else LOG.error
+                    log = LOG.info if c.is_success() else LOG.error
                     log(_indent(c.description, 2))
 
             if args.out_file is not None:

--- a/spid_compliant_certificates/commons/logger.py
+++ b/spid_compliant_certificates/commons/logger.py
@@ -56,7 +56,7 @@ if platform.system() == 'Windows':
     fmt = '[%(levelname)1.1s] %(message)s'
     _sh.setFormatter(logging.Formatter(fmt))
 else:
-    levelname = _c('%(levelname)-5.5s')
+    levelname = _c('%(levelname)1.1s')
     fmt = '[' + levelname + '] %(message)s'
     _sh.setFormatter(logging.Formatter(fmt))
     _sh.addFilter(ColourFilter())

--- a/spid_compliant_certificates/validator/checks/basic_constraints.py
+++ b/spid_compliant_certificates/validator/checks/basic_constraints.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 from cryptography import x509
 
@@ -26,7 +26,7 @@ SUCCESS = True
 FAILURE = not SUCCESS
 
 
-def basic_constraints(extensions: x509.Extensions) -> List[Tuple[bool, str]]:
+def basic_constraints(extensions: x509.Extensions) -> List[Tuple[bool, str, Any]]:  # noqa
     checks = []
 
     # basicConstraints: CA:FALSE
@@ -36,15 +36,15 @@ def basic_constraints(extensions: x509.Extensions) -> List[Tuple[bool, str]]:
     try:
         ext = extensions.get_extension_for_class(ext_cls)
 
-        msg = f'{ext_name} can not be set as critical'
+        msg = f'{ext_name} must be not critical'
         res = FAILURE if ext.critical else SUCCESS
-        checks.append((res, msg))
+        checks.append((res, msg, ext.critical))
 
-        msg = 'CA must be FALSE'
+        msg = 'CA extension property must be FALSE'
         res = FAILURE if ext.value.ca else SUCCESS
-        checks.append((res, msg))
+        checks.append((res, msg, ext.value.ca))
     except x509.ExtensionNotFound:
         msg = f'{ext_name} must be present'
-        checks.append((FAILURE, msg))
+        checks.append((FAILURE, msg, None))
 
     return checks

--- a/spid_compliant_certificates/validator/checks/digest_algorithm.py
+++ b/spid_compliant_certificates/validator/checks/digest_algorithm.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 from cryptography.hazmat.primitives import hashes
 
@@ -31,11 +31,11 @@ ALLOWED_ALGS = [
 ]
 
 
-def digest_algorithm(alg: str) -> List[Tuple[bool, str]]:
+def digest_algorithm(alg: str) -> List[Tuple[bool, str, Any]]:
     checks = []
 
-    msg = f'The digest algorithm must be one of {ALLOWED_ALGS} (now: {alg})'
+    msg = f'The digest algorithm must be one of {ALLOWED_ALGS}'
     res = FAILURE if alg not in ALLOWED_ALGS else SUCCESS
-    checks.append((res, msg))
+    checks.append((res, msg, alg))
 
     return checks

--- a/spid_compliant_certificates/validator/checks/key_type_and_size.py
+++ b/spid_compliant_certificates/validator/checks/key_type_and_size.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -33,7 +33,7 @@ ALLOWED_SIZES = [
 ]
 
 
-def key_type_and_size(cert: x509.Certificate) -> List[Tuple[bool, str]]:
+def key_type_and_size(cert: x509.Certificate) -> List[Tuple[bool, str, Any]]:
     checks = []
 
     # get the public key
@@ -44,18 +44,18 @@ def key_type_and_size(cert: x509.Certificate) -> List[Tuple[bool, str]]:
     pk_type = 'RSA' if isinstance(pk, rsa.RSAPublicKey) else 'NOT ALLOWED'
     msg = f'The keypair must be {exp_pk_type}'
     res = FAILURE if pk_type != exp_pk_type else SUCCESS
-    checks.append((res, msg))
+    checks.append((res, msg, pk_type))
 
     # check the key size
     min_size = 2048
     size = pk.key_size
 
-    msg = f'The key size must be greater than or equal to {min_size} (now: {size})'  # noqa
+    msg = f'The key size must be greater than or equal to {min_size}'
     res = FAILURE if size < min_size else SUCCESS
-    checks.append((res, msg))
+    checks.append((res, msg, size))
 
-    msg = f'The key size must be one of {ALLOWED_SIZES} (now: {size})'
+    msg = f'The key size must be one of {ALLOWED_SIZES}'
     res = FAILURE if size not in ALLOWED_SIZES else SUCCESS
-    checks.append((res, msg))
+    checks.append((res, msg, size))
 
     return checks

--- a/spid_compliant_certificates/validator/checks/subject_dn.py
+++ b/spid_compliant_certificates/validator/checks/subject_dn.py
@@ -60,7 +60,7 @@ def subject_dn(subj: x509.Name, sector: str) -> List[Tuple[bool, str]]:
 
     # check if not allowed attrs are present
     for attr in NOT_ALLOWED_ATTRS:
-        msg = 'Name attribute [{attr._name}, {attr.dotted_string}] is not allowed in subjectDN'  # noqa
+        msg = f'Name attribute [{attr._name}, {attr.dotted_string}] is not allowed in subjectDN'  # noqa
         res = FAILURE if attr in subj_attrs else SUCCESS
         checks.append((res, msg))
 

--- a/spid_compliant_certificates/validator/report.py
+++ b/spid_compliant_certificates/validator/report.py
@@ -1,0 +1,92 @@
+# Copyright 2021 Paolo Smiraglia <paolo.smiraglia@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+from typing import Callable, List, Tuple
+
+SUCCESS = True
+FAILURE = not SUCCESS
+
+
+class Report(object):
+    def __init__(self):
+        self.result = 'success'
+        self.tests = []
+
+    def add_test_result(self, checks: List[Tuple[bool, str]], description: str) -> None:  # noqa
+        test = {}
+        test['test'] = description
+        test['result'] = 'success'
+        test['checks'] = []
+
+        for res, msg in checks:
+            if res is FAILURE:
+                test['result'] = 'failure'
+                self.result = 'failure'
+                break
+
+        for res, msg in checks:
+            check = {}
+            check['check'] = msg
+            check['value'] = None
+            if res is FAILURE:
+                check['result'] = 'failure'
+            else:
+                check['result'] = 'success'
+            test['checks'].append(check)
+
+        self.tests.append(test)
+
+
+class ReportSerializer(object):
+    def serialize(self, report: Report, format: str) -> str:
+        serializer = self._get_serializer(format)
+        return serializer(report)
+
+    def _get_serializer(self, format: str) -> Callable[[Report], str]:
+        if format == 'json':
+            return self._json_serializer
+        elif format == 'txt':
+            return self._txt_serializer
+        elif format == 'xml':
+            return self._xml_serializer
+        else:
+            emsg = f'Format {format} is not accepted'
+            raise ValueError(emsg)
+
+    def _json_serializer(self, report: Report) -> str:
+        json_report = {}
+        json_report['result'] = report.result
+        json_report['tests'] = report.tests
+        return json.dumps(json_report)
+
+    def _txt_serializer(self, report: Report) -> str:
+        lines = []
+        lines.append(f'Validation result: {report.result}')
+
+        for test in report.tests:
+            lines.append(f'\t{test["test"]}: {test["result"]}')
+            for check in test['checks']:
+                lines.append(f'\t\t{check["check"]}: {check["result"]} ({check["value"]})')  # noqa
+
+        return '\n'.join(lines)
+
+    def _xml_serializer(self, report: Report) -> str:
+        return '<validation><result>failure</result></validation>'

--- a/spid_compliant_certificates/validator/report.py
+++ b/spid_compliant_certificates/validator/report.py
@@ -44,6 +44,9 @@ class Check(object):
         else:
             return f'{self.description} [{self.result}][{self.value}]'
 
+    def is_success(self) -> bool:
+        return (True if self.result == 'success' else False)
+
 
 class Test(object):
     def __init__(self, description: str):
@@ -52,7 +55,7 @@ class Test(object):
         self.checks = []
 
     def add_check(self, check: Check) -> None:
-        if check.result == 'failure':
+        if not check.is_success():
             self.result = 'failure'
         self.checks.append(check)
 
@@ -71,6 +74,9 @@ class Test(object):
             lines.append(line)
         return '\n'.join(lines)
 
+    def is_success(self) -> bool:
+        return (True if self.result == 'success' else False)
+
 
 class Report(object):
     def __init__(self, target: str):
@@ -80,7 +86,7 @@ class Report(object):
         self.tests = []
 
     def add_test(self, test: Test) -> None:
-        if test.result == 'failure':
+        if not test.is_success():
             self.result = 'failure'
         self.tests.append(test)
 
@@ -90,6 +96,9 @@ class Report(object):
             d[k] = getattr(self, k)
         d['tests'] = [t.as_dict() for t in self.tests]
         return d
+
+    def is_success(self) -> bool:
+        return (True if self.result == 'success' else False)
 
 
 class ReportSerializer(object):

--- a/spid_compliant_certificates/validator/validate.py
+++ b/spid_compliant_certificates/validator/validate.py
@@ -43,42 +43,42 @@ def validate(crt_file: str, sector: str) -> Report:
     else:
         raise Exception(msg)
 
-    r = Report(str(crt_file.absolute()))
+    rep = Report(str(crt_file.absolute()))
 
     # check key type and size
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.key_type_and_size(crt),
         'Checking the key type and size'
     ))
 
     # check digest algorithm
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.digest_algorithm(crt.signature_hash_algorithm.name),
         'Checking the signature digest algorithm'
     ))
 
     # check SubjectDN
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.subject_dn(crt.subject, sector),
         'Checking the SubjectDN'
     ))
 
     # check basicConstraints
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.basic_constraints(crt.extensions),
         'Checking basicConstraints x509 extension'
     ))
 
     # check keyUsage
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.key_usage(crt.extensions),
         'Checking keyUsage x509 extension'
     ))
 
     # check certificatePolicies
-    r.add_test(_do_check(
+    rep.add_test(_do_check(
         checks.certificate_policies(crt.extensions, sector),
         'Checking certificatePolicies x509 extension'
     ))
 
-    return r
+    return rep

--- a/spid_compliant_certificates/validator/validate.py
+++ b/spid_compliant_certificates/validator/validate.py
@@ -22,53 +22,16 @@ from typing import List, Tuple
 
 from cryptography import x509
 
-from spid_compliant_certificates.commons import logger
 from spid_compliant_certificates.validator import checks
 from spid_compliant_certificates.validator.report import Check, Report, Test
 from spid_compliant_certificates.validator.utils import pem_to_der
 
-LOG = logger.LOG
 
-SUCCESS = True
-FAILURE = not SUCCESS
-
-
-def _indent(txt: str, count=1) -> str:
-    i = '    '
-    return f'{i * count}{txt}'
-
-
-def _do_check_v1(checks: List[Tuple[bool, str]], base_msg: str) -> bool:
-    is_success = True
-
-    for res, msg in checks:
-        if res is FAILURE:
-            is_success = False
-            break
-
-    if is_success:
-        LOG.info(f'{base_msg}: success')
-    else:
-        LOG.error(f'{base_msg}: failure')
-
-    for res, msg in checks:
-        if res is FAILURE:
-            LOG.error(_indent(msg))
-        else:
-            LOG.info(_indent(msg))
-
-    return is_success
-
-
-def _do_check_v2(checks: List[Tuple[bool, str]], base_msg: str) -> Test:
+def _do_check(checks: List[Tuple[bool, str]], base_msg: str) -> Test:
     t = Test(base_msg)
     for res, msg, val in checks:
         t.add_check(Check(msg, 'success' if res else 'failure', val))
     return t
-
-
-def _do_check(checks: List[Tuple[bool, str]], base_msg: str) -> bool:
-    return _do_check_v2(checks, base_msg)
 
 
 def validate(crt_file: str, sector: str) -> Report:

--- a/spid_compliant_certificates/validator/validate.py
+++ b/spid_compliant_certificates/validator/validate.py
@@ -62,8 +62,8 @@ def _do_check_v1(checks: List[Tuple[bool, str]], base_msg: str) -> bool:
 
 def _do_check_v2(checks: List[Tuple[bool, str]], base_msg: str) -> Test:
     t = Test(base_msg)
-    for res, msg in checks:
-        t.add_check(Check(msg, 'success' if res else 'failure', None))
+    for res, msg, val in checks:
+        t.add_check(Check(msg, 'success' if res else 'failure', val))
     return t
 
 
@@ -112,7 +112,7 @@ def validate(crt_file: str, sector: str) -> Report:
         'Checking keyUsage x509 extension'
     ))
 
-    # check certificatePolicier
+    # check certificatePolicies
     r.add_test(_do_check(
         checks.certificate_policies(crt.extensions, sector),
         'Checking certificatePolicies x509 extension'


### PR DESCRIPTION
**Scope of the pull request**

The PR introduces the `--out-form` and `--out-file` switches. They instruct the application about **how** the validation report must be serialized (e.g. JSON, TXT, XML) and **where** it must be saved.

```
$ spid-compliant-certificates validator --out-file report.json --out-form json
   _____ _____ _____ _____     _____                      _ _             _
  / ____|  __ \_   _|  __ \   / ____|                    | (_)           | |
 | (___ | |__) || | | |  | | | |     ___  _ __ ___  _ __ | |_  __ _ _ __ | |_
  \___ \|  ___/ | | | |  | | | |    / _ \| '_ ` _ \| '_ \| | |/ _` | '_ \| __|
  ____) | |    _| |_| |__| | | |___| (_) | | | | | | |_) | | | (_| | | | | |_
 |_____/|_|   |_____|_____/   \_____\___/|_| |_| |_| .__/|_|_|\__,_|_| |_|\__|
   _____          _   _  __ _           _          | |
  / ____|        | | (_)/ _(_)         | |         |_|
 | |     ___ _ __| |_ _| |_ _  ___ __ _| |_ ___  ___
 | |    / _ \ '__| __| |  _| |/ __/ _` | __/ _ \/ __|
 | |___|  __/ |  | |_| | | | | (_| (_| | ||  __/\__ \
  \_____\___|_|   \__|_|_| |_|\___\__,_|\__\___||___/  v0.1




[I] Validating certificate /path/to/crt.pem against public sector specifications
[I] Certificate /path/to/crt.pem matches the public sector specifications

[ . . . ]

[I] Saving report as JSON in /path/to/report.json
```

**Closed issues**

- Close #21 
- Close #22

**Added issues**

- #24
- #25

**Tests**

- [X] I manually tested it
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
