### PR TITLE
Substitute GITHUB_TOKEN with personal access token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - test-wf
     tags:
     - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - test-wf
     tags:
     - 'v*'
 

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -7,11 +7,28 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  check_secrets:
+    name: Check secrets
+    runs-on: ubuntu-latest
+    outputs:
+      PAT: ${{ steps.pat.outputs.is_set }}
+      ALL: ${{ steps.pat.outputs.is_set }}
+    steps:
+    -
+      name: Check PAT
+      id: pat
+      run: |
+        echo "is_set: ${{ secrets.PAT != '' }}"
+        echo "::set-output name=is_set::${{ secrets.PAT != '' }}"
   update_release_draft:
     name: Update draft release
     runs-on: ubuntu-latest
+    needs:
+    - check_secrets
     steps:
     -
+      if: ${{ needs.check_secrets.outputs.PAT == 'true' }}
+      name: Draft next release
       uses: release-drafter/release-drafter@v5
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -2,7 +2,7 @@ name: Release drafter
 
 on:
   push:
-    branches: [main, test-wf]
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -2,7 +2,7 @@ name: Release drafter
 
 on:
   push:
-    branches: [main]
+    branches: [main, test-wf]
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
**Scope of the pull request**

Use personal access token instead of `GITHUB_TOKEN` in `release_drafter` workflow.

@peppelinux @bfabio The PR introduces the need of creating a new repository secret named `PAT` that stores a personal access token with `repo` and `workflow` scopes. The PAT should be related to the repository owner.

**Closed issues**

- Close #30

**Added issues**

None

**Tests**

- [X] I manually tested it
- [ ] I added unit test
- [ ] I ran the existing unit test and they do not fail
